### PR TITLE
Fixes + disableforanimals option

### DIFF
--- a/QuickLootRE.toml
+++ b/QuickLootRE.toml
@@ -2,3 +2,4 @@
 closeInCombat = false	# Automatically closes the loot menu in combat
 closeOnEmpty = true	# Automatically closes the loot menu if the container is empty
 dispelInvis = true	# Dispels invisibility when looting a container
+disableAnimals = false # Disables the loot menu for animals

--- a/src/Animation/Animation.h
+++ b/src/Animation/Animation.h
@@ -97,7 +97,7 @@ namespace Animation
 		{
 			const RE::BSFixedString anim(a_animation);
 			auto original = a_response.GetHandler(anim);
-			a_response.handlerMap.insert_or_assign(
+			a_response.handlerMap.insert(
 				{ std::move(anim),
 					RE::make_smart<AnimHandler>(std::move(original)) });
 		}

--- a/src/Events/Events.h
+++ b/src/Events/Events.h
@@ -93,8 +93,11 @@ namespace Events
 			}
 
 			if (auto actor = a_ref->As<RE::Actor>(); actor) {
+				auto dobj = RE::BGSDefaultObjectManager::GetSingleton();
+				auto keyword = dobj->GetObject<RE::BGSKeyword>(RE::DEFAULT_OBJECT::kKeywordAnimal);
 				if (!actor->IsDead() ||
 					actor->IsSummoned()) {
+					actor->IsSummoned() || (actor->GetRace()->HasKeyword(keyword) && *Settings::disableAnimals)) {
 					return false;
 				}
 			}

--- a/src/PCH.h
+++ b/src/PCH.h
@@ -87,6 +87,8 @@ namespace stl
 
 	using SKSE::util::to_underlying;
 
+	using nonstd::span;
+
 	namespace detail
 	{
 		template <class, class = void>

--- a/src/Settings.h
+++ b/src/Settings.h
@@ -26,4 +26,5 @@ struct Settings
 	static inline bSetting closeInCombat{ "General"s, "closeInCombat"s, true };
 	static inline bSetting closeOnEmpty{ "General"s, "closeOnEmpty"s, true };
 	static inline bSetting dispelInvis{ "General"s, "dispelInvis"s, true };
+	static inline bSetting disableAnimals{ "General"s, "disableAnimals"s, false };
 };

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -8,6 +8,7 @@
     "autotoml",
     "boost-atomic",
     "boost-regex",
+    "boost-stl-interfaces",
     "frozen",
     "span-lite",
     "spdlog",


### PR DESCRIPTION
Fixes some building issues and adds an option to disable for animals.

I am not sure if my way of checking the actor is an animal is optimal but I tested in game and it worked.

Due to changes to commonlib I think, some methods were removed. I don't know if what I did was a good "fix" but I haven't seen any problems in game so far.